### PR TITLE
Deprecate the `parallel` keyword and infer parallelization from `n_proc` > 1

### DIFF
--- a/docs/examples/get_emission_ang.py
+++ b/docs/examples/get_emission_ang.py
@@ -2,6 +2,7 @@ import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 from astropy.time import Time
+
 from zodipy import Zodipy
 
 model = Zodipy("dirbe")

--- a/docs/examples/get_parallel_emission.py
+++ b/docs/examples/get_parallel_emission.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import time
 
 import astropy.units as u
@@ -11,9 +10,10 @@ from zodipy import Zodipy
 nside = 256
 pixels = np.arange(hp.nside2npix(nside))
 obs_time = Time("2020-01-01")
+n_proc = 8
 
 model = Zodipy()
-model_parallel = Zodipy(parallel=True)
+model_parallel = Zodipy(n_proc=n_proc)
 
 start = time.perf_counter()
 emission = model.get_binned_emission_pix(
@@ -33,7 +33,7 @@ emission_parallel = model_parallel.get_binned_emission_pix(
     obs_time=obs_time,
 )
 print(
-    f"Time spent on {multiprocessing.cpu_count()} CPUs:",
+    f"Time spent on {n_proc} CPUs:",
     round(time.perf_counter() - start, 2),
     "seconds",
 )

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,7 +83,7 @@ read [Cosmoglobe: Simulating Zodiacal Emission with ZodiPy](https://arxiv.org/ab
 
 
 ## Parallelization
-If you are not using ZodiPy in an already parallelized environment **and** are working with large pointing sequences, setting `parallel=True` when initializing `Zodipy` will improve the performance. ZodiPy will then automatically distribute the pointing to all available CPU's, given by `multiprocessing.cpu_count()` or to `n_proc` if this argument is provided.
+If you are not using ZodiPy in an already parallelized environment, you may specify the number of cores used by ZodiPy through the `n_proc` keyword. By default `n_proc` is set to 1. For values of `n_proc` > 1, the line-of-sight calculations are parallelized using the `multiprocessing` module.
 
 ```python hl_lines="15 16"
 {!examples/get_parallel_emission.py!}
@@ -102,7 +102,7 @@ If you are not using ZodiPy in an already parallelized environment **and** are w
 !!! warning "Using ZodiPy in parallelized environments"
     If ZodiPy is used in a parallelized environment one may have to specifically set the environment variable 
     `OMP_NUM_THREADS=1` to avoid oversubscription. This is due automatic parallelization in third party libraries such as `healpy` where for instance the `hp.Rotator` object automatically parallelizes rotation of unit vectors.
-    This means that when using ZodiPy with pointing in a coordinate system other than ecliptic, even if `Zodipy` is initialized with `parallel=False`, `healpy` will under the hood automatically distribute the pointing to available CPU's.
+    This means that when using ZodiPy with pointing in a coordinate system other than ecliptic, even if `Zodipy` is initialized with `n_proc`=1, `healpy` will under the hood automatically distribute the pointing to available CPU's.
 
 
 ## Visualizing the interplanetary dust distribution of a model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ ignore = [
     "PLR0913",
     "ISC001"
 ]
-exclude = ["tests/*"]
+exclude = ["tests/*", "docs/*"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/tests/_strategies.py
+++ b/tests/_strategies.py
@@ -236,5 +236,5 @@ def model(draw: DrawFn, **static_params: dict[str, Any]) -> zodipy.Zodipy:
             strategies.pop(key)
 
     return draw(
-        builds(partial(zodipy.Zodipy, parallel=False, **static_params), **strategies)
+        builds(partial(zodipy.Zodipy, **static_params), **strategies)
     )

--- a/tests/test_get_emission.py
+++ b/tests/test_get_emission.py
@@ -252,8 +252,8 @@ def test_multiprocessing() -> None:
     without multiprocessing.
     """
 
-    model = Zodipy(parallel=False)
-    model_parallel = Zodipy(parallel=True)
+    model = Zodipy()
+    model_parallel = Zodipy(n_proc=4)
 
     observer = "earth"
     time = Time("2020-01-01")

--- a/tests/test_get_emission.py
+++ b/tests/test_get_emission.py
@@ -245,7 +245,6 @@ def test_invalid_pixel(
             obs=observer,
         )
 
-
 def test_multiprocessing() -> None:
     """
     Testing that model with multiprocessing enabled returns the same value as
@@ -331,6 +330,35 @@ def test_multiprocessing() -> None:
 
     assert np.allclose(emission_binned_ang.value, emission_binned_ang_parallel.value)
 
+def test_inner_radial_cutoff_multiprocessing() -> None:
+    """
+    Testing that model with inner radial cutoffs can be parallelized.
+    """
+
+    model = Zodipy("RRM-experimental")
+    model_parallel = Zodipy("RRM-experimental", n_proc=4)
+
+    observer = "earth"
+    time = Time("2020-01-01")
+    frequency = 78 * u.micron
+    nside = 32
+    pix = np.random.randint(0, hp.nside2npix(nside), size=1000)
+
+    emission_pix = model.get_emission_pix(
+        frequency,
+        pixels=pix,
+        nside=nside,
+        obs_time=time,
+        obs=observer,
+    )
+    emission_pix_parallel = model_parallel.get_emission_pix(
+        frequency,
+        pixels=pix,
+        nside=nside,
+        obs_time=time,
+        obs=observer,
+    )
+    assert np.allclose(emission_pix, emission_pix_parallel)
 
 @given(
     model(extrapolate=True),


### PR DESCRIPTION
As mentioned in #3, requiring two keywords to make use of parallelization is unecessary. Instead we now infer parallelization from the `n_proc` keyword solely.  This pull request fixes #3 