### PR TITLE
MNT: Unleash Dependabot on Actions

### DIFF
--- a/.github /dependabot.yml
+++ b/.github /dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: ".github/workflows" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
I noticed that your workflow versions are a little behind. This would auto-update them going forward. Example:

https://github.com/Cosmoglobe/zodipy/blob/1a99511426d640aaa2caa848013072ea4b79abd5/.github/workflows/tests.yml#L16

It is v5 now.