### PR TITLE
Add paper directory for JOSS listing. Add SciPy as a direct dependency

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -20,4 +20,4 @@ jobs:
           # This is the output path where Pandoc will write the compiled
           # PDF. Note, this should be the same directory as the input
           # paper.md
-          path: paper.pdf
+          path: paper/paper.pdf

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,0 +1,23 @@
+on: [push]
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          # This should be the path to the paper within your repo.
+          paper-path: paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: paper
+          # This is the output path where Pandoc will write the compiled
+          # PDF. Note, this should be the same directory as the input
+          # paper.md
+          path: paper.pdf

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           journal: joss
           # This should be the path to the paper within your repo.
-          paper-path: paper.md
+          paper-path: paper/paper.md
       - name: Upload
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   paper:

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ settings.json
 #files
 test.py
 context.py
+
+*.pdf

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ---
 
 
-ZodiPy is an [Astropy affiliated](https://www.astropy.org/affiliated/) package, which simulates the zodiacal light in intensity that an arbitrary solar system observer is predicted to see given an interplanetary dust model and a scanning strategy, either in the form of timestreams or HEALPix maps.
+ZodiPy is an [Astropy affiliated](https://www.astropy.org/affiliated/) package for simulating zodiacal light in intensity for arbitrary Solar system observers.
 
 ![plot](docs/img/zodipy_map.png)
 
@@ -29,6 +29,7 @@ ZodiPy supports all Python versions >= 3.8, and has the following dependencies:
 - [NumPy](https://numpy.org/)
 - [healpy](https://healpy.readthedocs.io/en/latest/)
 - [jplephem](https://pypi.org/project/jplephem/)
+- [SciPy](https://scipy.org/)
 
 
 # A simple example

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 [![arXiv Paper](https://img.shields.io/badge/arXiv-2205.12962-green?style=flat-square&logo=arxiv)](https://arxiv.org/abs/2205.12962)
 [![ascl:2306.012](https://img.shields.io/badge/ascl-2306.012-blue.svg?colorB=262255&style=flat-square)](https://ascl.net/2306.012)
 
-ZodiPy is an [Astropy affiliated](https://www.astropy.org/affiliated/) package, which simulates the zodiacal light in intensity that an arbitrary solar system observer is predicted to see given an interplanetary dust model and a scanning strategy, either in the form of timestreams or HEALPix maps.
+ZodiPy is an [Astropy affiliated](https://www.astropy.org/affiliated/) package for simulating zodiacal light in intensity for arbitrary Solar system observers.
 ![ZodiPy Logo](img/zodipy_map.png)
 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,8 +12,8 @@ pip install zodipy
 ## Dependencies
 ZodiPy has the following dependencies (these are automatically downloaded alongside ZodiPy):
 
-- [numpy](https://numpy.org)
-- [astropy](https://www.astropy.org) (>= 5.0.1)
+- [Astropy](https://www.astropy.org) (>= 5.0.1)
+- [NumPy](https://numpy.org)
 - [healpy](https://healpy.readthedocs.io/en/latest/)
 - [jplehem](https://pypi.org/project/jplephem/)
-- [scipy](https://scipy.org/)
+- [SciPy](https://scipy.org/)

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,3 +16,4 @@ ZodiPy has the following dependencies (these are automatically downloaded alongs
 - [astropy](https://www.astropy.org) (>= 5.0.1)
 - [healpy](https://healpy.readthedocs.io/en/latest/)
 - [jplehem](https://pypi.org/project/jplephem/)
+- [scipy](https://scipy.org/)

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,233 @@
+@software{2011ascl.soft12014R,
+  author       = {{Rhodes}, Brandon Craig},
+  title        = {{PyEphem: Astronomical Ephemeris for Python}},
+  howpublished = {Astrophysics Source Code Library, record ascl:1112.014},
+  year         = 2011,
+  month        = dec,
+  eid          = {ascl:1112.014},
+  adsurl       = {https://ui.adsabs.harvard.edu/abs/2011ascl.soft12014R},
+  adsnote      = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{2023arXiv230617219A,
+  author        = {{Aldering}, Greg and {Rubin}, David and {Rose}, Benjamin and {Hounsell}, Rebekah and {Perlmutter}, Saul and {Deustua}, Susana},
+  title         = {{Roman CCS White Paper: Balanced Prism Plus Filter Cadence in the High Latitude Time Domain Survey Core Community Survey}},
+  journal       = {arXiv e-prints},
+  keywords      = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
+  year          = 2023,
+  month         = jun,
+  eid           = {arXiv:2306.17219},
+  pages         = {arXiv:2306.17219},
+  doi           = {10.48550/arXiv.2306.17219},
+  archiveprefix = {arXiv},
+  eprint        = {2306.17219},
+  primaryclass  = {astro-ph.IM},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/2023arXiv230617219A},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{2023arXiv230617226R,
+  author        = {{Rose}, Benjamin and {Aldering}, Greg and {Hounsell}, Rebekah and {Joshi}, Bhavin and {Rubin}, David and {Scolnic}, Dan and {Perlmutter}, Saul and {Deustua}, Susana and {Sako}, Masao},
+  title         = {{Roman CCS White Paper: Considerations for Selecting Fields for the Roman High-latitude Time Domain Core Community Survey}},
+  journal       = {arXiv e-prints},
+  keywords      = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - High Energy Astrophysical Phenomena},
+  year          = 2023,
+  month         = jun,
+  eid           = {arXiv:2306.17226},
+  pages         = {arXiv:2306.17226},
+  doi           = {10.48550/arXiv.2306.17226},
+  archiveprefix = {arXiv},
+  eprint        = {2306.17226},
+  primaryclass  = {astro-ph.IM},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/2023arXiv230617226R},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{astropy,
+  author        = {{Astropy Collaboration}},
+  title         = {{Astropy: A community Python package for astronomy}},
+  journal       = {Astronomy and Astrophysics},
+  archiveprefix = {arXiv},
+  eprint        = {1307.6212},
+  primaryclass  = {astro-ph.IM},
+  keywords      = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+  year          = 2013,
+  month         = oct,
+  volume        = 558,
+  doi           = {10.1051/0004-6361/201322068},
+  url           = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A}
+}
+
+@article{Avitan2023,
+  author   = {Avitan, Or and Schechner, Yoav Y. and Behar, Ehud},
+  journal  = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  title    = {Using Zodiacal Light For Spaceborne Calibration Of Polarimetric Imagers},
+  year     = {2023},
+  volume   = {},
+  number   = {},
+  pages    = {1-12},
+  keywords = {Calibration;Scattering;Atmospheric modeling;Clouds;Sun;Earth;Space vehicles;Computational photography;Polarimetric calibration;Astronomy},
+  doi      = {10.1109/TPAMI.2023.3299526}
+}
+
+@article{Hanzawa2024,
+  author  = {Hanzawa, Masaki and Matsuura, Shuji and Takahashi, Aoi and Chary, Ranga-Ram and Sano, Kei and Takimoto, Kohji and Tome, Yuto},
+  title   = {{Measurement of the zodiacal light absolute intensity through Fraunhofer line spectroscopy of the night sky with the Hale telescope}},
+  journal = {Publications of the Astronomical Society of Japan},
+  pages   = {psae016},
+  year    = {2024},
+  month   = {03},
+  issn    = {2053-051X},
+  doi     = {10.1093/pasj/psae016},
+  url     = {https://doi.org/10.1093/pasj/psae016},
+  eprint  = {https://academic.oup.com/pasj/advance-article-pdf/doi/10.1093/pasj/psae016/57049109/psae016.pdf}
+}
+
+@article{Kelsall1998,
+  author        = {{Kelsall}, T. and {Weiland}, J.~L. and {Franz}, B.~A. and {Reach}, W.~T. and {Arendt}, R.~G. and {Dwek}, E. and {Freudenreich}, H.~T. and {Hauser}, M.~G. and {Moseley}, S.~H. and {Odegard}, N.~P. and {Silverberg}, R.~F. and {Wright}, E.~L.},
+  title         = {{The COBE Diffuse Infrared Background Experiment Search for the Cosmic Infrared Background. II. Model of the Interplanetary Dust Cloud}},
+  journal       = {\apj},
+  keywords      = {COSMOLOGY: OBSERVATIONS, COSMOLOGY: DIFFUSE RADIATION, INFRARED: GENERAL, INFRARED: SOLAR SYSTEM, INTERPLANETARY MEDIUM, Cosmology: Observations, Cosmology: Diffuse Radiation, Infrared: General, Infrared: Solar System, Interplanetary Medium, Astrophysics},
+  year          = 1998,
+  month         = nov,
+  volume        = {508},
+  number        = {1},
+  pages         = {44-73},
+  doi           = {10.1086/306380},
+  archiveprefix = {arXiv},
+  eprint        = {astro-ph/9806250},
+  primaryclass  = {astro-ph},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/1998ApJ...508...44K},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+} 
+
+@article{numpy2011,
+  author  = {van der Walt, Stefan and Colbert, S. Chris and Varoquaux, Gael},
+  journal = {Computing in Science & Engineering},
+  title   = {The {NumPy} Array: A Structure for Efficient Numerical Computation},
+  year    = {2011},
+  volume  = {13},
+  number  = {2},
+  pages   = {22-30},
+  doi     = {10.1109/MCSE.2011.37}
+}
+
+@article{numpy2020,
+  title     = {Array programming with {NumPy}},
+  author    = {Charles R. Harris and K. Jarrod Millman and St{\'{e}}fan J.
+               van der Walt and Ralf Gommers and Pauli Virtanen and David
+               Cournapeau and Eric Wieser and Julian Taylor and Sebastian
+               Berg and Nathaniel J. Smith and Robert Kern and Matti Picus
+               and Stephan Hoyer and Marten H. van Kerkwijk and Matthew
+               Brett and Allan Haldane and Jaime Fern{\'{a}}ndez del
+               R{\'{i}}o and Mark Wiebe and Pearu Peterson and Pierre
+               G{\'{e}}rard-Marchant and Kevin Sheppard and Tyler Reddy and
+               Warren Weckesser and Hameer Abbasi and Christoph Gohlke and
+               Travis E. Oliphant},
+  year      = {2020},
+  month     = sep,
+  journal   = {Nature},
+  volume    = {585},
+  number    = {7825},
+  pages     = {357--362},
+  doi       = {10.1038/s41586-020-2649-2},
+  publisher = {Springer Science and Business Media {LLC}},
+  url       = {https://doi.org/10.1038/s41586-020-2649-2}
+}
+
+@article{Planck2014,
+  author        = {{Planck Collaboration} and {Ade}, P.~A.~R. and {Aghanim}, N. and {Armitage-Caplan}, C. and {Arnaud}, M. and {Ashdown}, M. and {Atrio-Barandela}, F. and {Aumont}, J. and {Baccigalupi}, C. and {Banday}, A.~J. and {Barreiro}, R.~B. and {Bartlett}, J.~G. and {Battaner}, E. and {Benabed}, K. and {Beno{\^\i}t}, A. and {Benoit-L{\'e}vy}, A. and {Bernard}, J. -P. and {Bersanelli}, M. and {Bielewicz}, P. and {Bobin}, J. and {Bock}, J.~J. and {Bonaldi}, A. and {Bond}, J.~R. and {Borrill}, J. and {Bouchet}, F.~R. and {Boulanger}, F. and {Bridges}, M. and {Bucher}, M. and {Burigana}, C. and {Butler}, R.~C. and {Cardoso}, J. -F. and {Catalano}, A. and {Chamballu}, A. and {Chary}, R. -R. and {Chen}, X. and {Chiang}, H.~C. and {Chiang}, L. -Y. and {Christensen}, P.~R. and {Church}, S. and {Clements}, D.~L. and {Colley}, J. -M. and {Colombi}, S. and {Colombo}, L.~P.~L. and {Couchot}, F. and {Coulais}, A. and {Crill}, B.~P. and {Curto}, A. and {Cuttaia}, F. and {Danese}, L. and {Davies}, R.~D. and {de Bernardis}, P. and {de Rosa}, A. and {de Zotti}, G. and {Delabrouille}, J. and {Delouis}, J. -M. and {D{\'e}sert}, F. -X. and {Dickinson}, C. and {Diego}, J.~M. and {Dole}, H. and {Donzelli}, S. and {Dor{\'e}}, O. and {Douspis}, M. and {Dupac}, X. and {Efstathiou}, G. and {En{\ss}lin}, T.~A. and {Eriksen}, H.~K. and {Finelli}, F. and {Forni}, O. and {Frailis}, M. and {Fraisse}, A.~A. and {Franceschi}, E. and {Galeotta}, S. and {Ganga}, K. and {Giard}, M. and {Giraud-H{\'e}raud}, Y. and {Gonz{\'a}lez-Nuevo}, J. and {G{\'o}rski}, K.~M. and {Gratton}, S. and {Gregorio}, A. and {Gruppuso}, A. and {Hansen}, F.~K. and {Hanson}, D. and {Harrison}, D. and {Helou}, G. and {Henrot-Versill{\'e}}, S. and {Hern{\'a}ndez-Monteagudo}, C. and {Herranz}, D. and {Hildebrandt}, S.~R. and {Hivon}, E. and {Hobson}, M. and {Holmes}, W.~A. and {Hornstrup}, A. and {Hovest}, W. and {Huffenberger}, K.~M. and {Jaffe}, A.~H. and {Jaffe}, T.~R. and {Jones}, W.~C. and {Juvela}, M. and {Keih{\"a}nen}, E. and {Keskitalo}, R. and {Kisner}, T.~S. and {Kneissl}, R. and {Knoche}, J. and {Knox}, L. and {Kunz}, M. and {Kurki-Suonio}, H. and {Lagache}, G. and {L{\"a}hteenm{\"a}ki}, A. and {Lamarre}, J. -M. and {Lasenby}, A. and {Laureijs}, R.~J. and {Lawrence}, C.~R. and {Leonardi}, R. and {Lesgourgues}, J. and {Liguori}, M. and {Lilje}, P.~B. and {Linden-V{\o}rnle}, M. and {L{\'o}pez-Caniego}, M. and {Lubin}, P.~M. and {Mac{\'\i}as-P{\'e}rez}, J.~F. and {Maffei}, B. and {Maino}, D. and {Mandolesi}, N. and {Maris}, M. and {Marshall}, D.~J. and {Martin}, P.~G. and {Mart{\'\i}nez-Gonz{\'a}lez}, E. and {Masi}, S. and {Massardi}, M. and {Matarrese}, S. and {Matthai}, F. and {Mazzotta}, P. and {Meinhold}, P.~R. and {Melchiorri}, A. and {Mendes}, L. and {Mennella}, A. and {Migliaccio}, M. and {Mitra}, S. and {Miville-Desch{\^e}nes}, M. -A. and {Moneti}, A. and {Montier}, L. and {Morgante}, G. and {Mortlock}, D. and {Mottet}, S. and {Munshi}, D. and {Murphy}, J.~A. and {Naselsky}, P. and {Nati}, F. and {Natoli}, P. and {Netterfield}, C.~B. and {N{\o}rgaard-Nielsen}, H.~U. and {Noviello}, F. and {Novikov}, D. and {Novikov}, I. and {Osborne}, S. and {O'Sullivan}, C. and {Oxborrow}, C.~A. and {Paci}, F. and {Pagano}, L. and {Pajot}, F. and {Paladini}, R. and {Paoletti}, D. and {Pasian}, F. and {Patanchon}, G. and {Perdereau}, O. and {Perotto}, L. and {Perrotta}, F. and {Piacentini}, F. and {Piat}, M. and {Pierpaoli}, E. and {Pietrobon}, D. and {Plaszczynski}, S. and {Pointecouteau}, E. and {Polegre}, A.~M. and {Polenta}, G. and {Ponthieu}, N. and {Popa}, L. and {Poutanen}, T. and {Pratt}, G.~W. and {Pr{\'e}zeau}, G. and {Prunet}, S. and {Puget}, J. -L. and {Rachen}, J.~P. and {Reach}, W.~T. and {Rebolo}, R. and {Reinecke}, M. and {Remazeilles}, M. and {Renault}, C. and {Ricciardi}, S. and {Riller}, T. and {Ristorcelli}, I. and {Rocha}, G. and {Rosset}, C. and {Roudier}, G. and {Rowan-Robinson}, M. and {Rusholme}, B. and {Sandri}, M. and {Santos}, D. and {Savini}, G. and {Scott}, D. and {Seiffert}, M.~D. and {Shellard}, E.~P.~S. and {Smoot}, G.~F. and {Spencer}, L.~D. and {Starck}, J. -L. and {Stolyarov}, V. and {Stompor}, R. and {Sudiwala}, R. and {Sureau}, F. and {Sutton}, D. and {Suur-Uski}, A. -S. and {Sygnet}, J. -F. and {Tauber}, J.~A. and {Tavagnacco}, D. and {Terenzi}, L. and {Toffolatti}, L. and {Tomasi}, M. and {Tristram}, M. and {Tucci}, M. and {Tuovinen}, J. and {Umana}, G. and {Valenziano}, L. and {Valiviita}, J. and {Van Tent}, B. and {Vielva}, P. and {Villa}, F. and {Vittorio}, N. and {Wade}, L.~A. and {Wandelt}, B.~D. and {Yvon}, D. and {Zacchei}, A. and {Zonca}, A.},
+  title         = {{Planck 2013 results. XIV. Zodiacal emission}},
+  journal       = {\aap},
+  keywords      = {zodiacal dust, interplanetary medium, cosmic background radiation, Astrophysics - Cosmology and Nongalactic Astrophysics},
+  year          = 2014,
+  month         = nov,
+  volume        = {571},
+  eid           = {A14},
+  pages         = {A14},
+  doi           = {10.1051/0004-6361/201321562},
+  archiveprefix = {arXiv},
+  eprint        = {1303.5074},
+  primaryclass  = {astro-ph.CO},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/2014A&A...571A..14P},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{San2022,
+  author        = {{San}, M. and {Herman}, D. and {Erikstad}, G.~B. and {Galloway}, M. and {Watts}, D.},
+  title         = {{COSMOGLOBE: Simulating zodiacal emission with ZodiPy}},
+  journal       = {\aap},
+  keywords      = {interplanetary medium, cosmic background radiation, zodiacal dust, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
+  year          = 2022,
+  month         = oct,
+  volume        = {666},
+  eid           = {A107},
+  pages         = {A107},
+  doi           = {10.1051/0004-6361/202244133},
+  archiveprefix = {arXiv},
+  eprint        = {2205.12962},
+  primaryclass  = {astro-ph.EP},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/2022A&A...666A.107S},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{scipy2020,
+  author  = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and Haberland, Matt and Reddy, Tyler and Cournapeau, David and Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and Bright, Jonathan and {van der Walt}, St{\'e}fan J. and Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and Kern, Robert and Larson, Eric and Carey, C J and Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and {VanderPlas}, Jake and Laxalde, Denis and Perktold, Josef and Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and Harris, Charles R. and Archibald, Anne M. and Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
+  title   = {{{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in Python}},
+  journal = {Nature Methods},
+  year    = {2020},
+  volume  = {17},
+  pages   = {261--272},
+  adsurl  = {https://rdcu.be/b08Wh},
+  doi     = {10.1038/s41592-019-0686-2}
+}
+
+@article{Tsumura2023,
+  author        = {{Tsumura}, Kohji and {Matsuura}, Shuji and {Sano}, Kei and {Iwata}, Takahiro and {Yano}, Hajime and {Kitazato}, Kohei and {Takimoto}, Kohji and {Yamada}, Manabu and {Morota}, Tomokatsu and {Kouyama}, Toru and {Hayakawa}, Masahiko and {Yokota}, Yasuhiro and {Tatsumi}, Eri and {Matsuoka}, Moe and {Sakatani}, Naoya and {Honda}, Rie and {Kameda}, Shingo and {Suzuki}, Hidehiko and {Cho}, Yuichiro and {Yoshioka}, Kazuo and {Ogawa}, Kazunori and {Shirai}, Kei and {Sawada}, Hirotaka and {Sugita}, Seiji},
+  title         = {{Heliocentric distance dependence of zodiacal light observed by Hayabusa2\#}},
+  journal       = {Earth, Planets and Space},
+  keywords      = {Zodiacal light, Interplanetary dust, Hayabusa2\#, Astrophysics - Earth and Planetary Astrophysics},
+  year          = 2023,
+  month         = dec,
+  volume        = {75},
+  number        = {1},
+  eid           = {121},
+  pages         = {121},
+  doi           = {10.1186/s40623-023-01856-x},
+  archiveprefix = {arXiv},
+  eprint        = {2303.07013},
+  primaryclass  = {astro-ph.EP},
+  adsurl        = {https://ui.adsabs.harvard.edu/abs/2023EP&S...75..121T},
+  adsnote       = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{Zonca2019,
+  doi       = {10.21105/joss.01298},
+  url       = {https://doi.org/10.21105/joss.01298},
+  year      = {2019},
+  publisher = {The Open Journal},
+  volume    = {4},
+  number    = {35},
+  pages     = {1298},
+  author    = {Andrea Zonca and Leo P. Singer and Daniel Lenz and Martin Reinecke and Cyrille Rosset and Eric Hivon and Krzysztof M. Gorski},
+  title     = {healpy: equal area pixelization and spherical harmonics transforms for data on the sphere in Python},
+  journal   = {Journal of Open Source Software}
+}
+
+@article{Gorski2005,
+       author = {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday}, A.~J. and {Wandelt}, B.~D. and {Hansen}, F.~K. and {Reinecke}, M. and {Bartelmann}, M.},
+        title = "{HEALPix: A Framework for High-Resolution Discretization and Fast Analysis of Data Distributed on the Sphere}",
+      journal = {\apj},
+     keywords = {Cosmology: Cosmic Microwave Background, Cosmology: Observations, Methods: Statistical, Astrophysics},
+         year = 2005,
+        month = apr,
+       volume = {622},
+       number = {2},
+        pages = {759-771},
+          doi = {10.1086/427976},
+archivePrefix = {arXiv},
+       eprint = {astro-ph/0409513},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2005ApJ...622..759G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -19,8 +19,8 @@ bibliography: paper.bib
 
 # Optional fields if submitting to a AAS journal too, see this blog post:
 # https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
-aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
-aas-journal: Astrophysical Journal <- The name of the AAS journal.
+# aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
+# aas-journal: Astrophysical Journal <- The name of the AAS journal.
 ---
 
 # Summary

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,82 @@
+---
+title: 'ZodiPy: A Python package for zodiacal light simulations'
+tags:
+  - Python
+  - astronomy
+  - cosmology
+  - zodiacal light
+  - interplanetary dust
+authors:
+  - name: Metin San
+    orcid: 0000-0003-4648-8729
+    equal-contrib: true
+    affiliation: "1"
+affiliations:
+ - name: Metin San, PhD. Fellow, University of Oslo, Norway
+   index: 1
+date: 10 April 2024
+bibliography: paper.bib
+
+# Optional fields if submitting to a AAS journal too, see this blog post:
+# https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
+aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
+aas-journal: Astrophysical Journal <- The name of the AAS journal.
+---
+
+# Summary
+`ZodiPy` is an Astropy-affiliated Python package for zodiacal light simulations. 
+Its purpose is to provide the astrophysics and cosmology communities with an 
+accessible and easy-to-use Python interface to existing zodiacal light models, 
+assisting in the analysis of astrophysical data and enabling quick and easy 
+zodiacal light forecasting for future experiments. `ZodiPy` implements the 
+[@Kelsall1998] and the [@Planck2014] interplanetary dust models, which allows for
+zodiacal light simulations between $1.25-240\mu$m and $30-857$GHz, respectively, 
+with the possibility to extrapolate the models to other frequencies. 
+
+# Statement of need
+Zodiacal light is the main source of diffuse radiation observed in the infrared 
+sky between $1-100\mu$m. The light is the result of scattering and re-emission of 
+sunlight by dust grains in the interplanetary medium. Zodiacal light is one of the 
+most challenging foregrounds to model in cosmological studies of the Extragalactic 
+Background Light (EBL) in the infrared sky, primarily due to its seasonal nature. 
+
+Traditionally, observers of the infrared sky have had to build their own zodiacal 
+light tools (see the
+[LAMBDA foreground models page](https://lambda.gsfc.nasa.gov/product/foreground/fg_models.html) 
+for a list of existing tools). However, these programs are either 
+only usable for the specific experiments for which the tool was made, or unaccessible 
+as they require the use of licensed programing languages or unpractical web 
+interfaces. Much of modern astronomy and cosmology is done in Python due to the wide 
+range of available high quality tools and open source projects and communities, such as 
+the Astropy project [@astropy]. The lack of a general purpose zodiacal light tool 
+in this space was the main motivation behind the development of the `ZodiPy` package.
+
+When using `ZodiPy`, the user is required to provide the following data: 
+
+1) A set of observations, in either ecliptic or galactic coordinates, in the form of 
+angular sky coordinates or as HEALPIx [@Gorski2005] pixel indices.
+2) A center frequency or a bandpass.
+3) The time of observation. 
+4) The heliocentric position of the observer, although this may be omitted if the 
+observer is located at the position of a major solar system object, such as on Earth 
+or at the Sun-Earth-Moon barycenter L2. In this case the position is queried directly 
+through the `astropy.coordinates` solar system ephemeridis. 
+
+This information is then used to evaluate a sequence of line-of-sight integrals through 
+a three-dimensional model of the interplanetary dust distribution. For more details 
+about the implementation and the models used we refer to the following paper on `ZodiPy`
+[@San2022].
+
+`ZodiPy` has been used by several research projects[@2023arXiv230617219A; 
+@2023arXiv230617226R; @Tsumura2023; @Avitan2023; @Hanzawa2024] with applications ranging from assistance in determining the observational fields of the coming NASA Roman Space Telescope, to model data obtained aboard the Hayabusa2 JAXA satellite. 
+
+# Acknowledgements
+The work to develop `ZodiPy`  has received funding from the European Union’s Horizon 
+2020 research and innovation programme under grant agreement numbers 819478 
+(ERC; Cosmoglobe) and 772253 (ERC;bits2cosmology).
+
+This project relies on the following Python packages: Astropy [@astropy], NumPy 
+[@numpy2011; @numpy2020], healpy [@Zonca2019], SciPy [@scipy2020], jplephem 
+[@2011ascl.soft12014R].
+
+# References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -30,7 +30,7 @@ Its purpose is to provide the astrophysics and cosmology communities with an
 accessible and easy-to-use Python interface to existing zodiacal light models, 
 assisting in the analysis of infrared astrophysical data and enabling quick and easy 
 zodiacal light forecasting for future experiments. `ZodiPy` implements the 
-[@Kelsall1998] and the [@Planck2014] interplanetary dust models, which allow for
+@Kelsall1998 and the @Planck2014 interplanetary dust models, which allow for
 zodiacal light simulations between $1.25-240\mu$m and $30-857$GHz, respectively, 
 with the possibility of extrapolating the models to other frequencies.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -27,15 +27,15 @@ bibliography: paper.bib
 `ZodiPy` is an Astropy-affiliated Python package for zodiacal light simulations. 
 Its purpose is to provide the astrophysics and cosmology communities with an 
 accessible and easy-to-use Python interface to existing zodiacal light models, 
-assisting in the analysis of astrophysical data and enabling quick and easy 
+assisting in the analysis of infrared astrophysical data and enabling quick and easy 
 zodiacal light forecasting for future experiments. `ZodiPy` implements the 
-[@Kelsall1998] and the [@Planck2014] interplanetary dust models, which allows for
+[@Kelsall1998] and the [@Planck2014] interplanetary dust models, which allow for
 zodiacal light simulations between $1.25-240\mu$m and $30-857$GHz, respectively, 
-with the possibility to extrapolate the models to other frequencies. 
+with the possibility of extrapolating the models to other frequencies.
 
 # Statement of need
 Zodiacal light is the main source of diffuse radiation observed in the infrared 
-sky between $1-100\mu$m. The light is the result of scattering and re-emission of 
+sky between $1-100\mu$m. The light comes from scattering and re-emission of 
 sunlight by dust grains in the interplanetary medium. Zodiacal light is one of the 
 most challenging foregrounds to model in cosmological studies of the Extragalactic 
 Background Light (EBL) in the infrared sky, primarily due to its seasonal nature. 
@@ -44,31 +44,36 @@ Traditionally, observers of the infrared sky have had to build their own zodiaca
 light tools (see the
 [LAMBDA foreground models page](https://lambda.gsfc.nasa.gov/product/foreground/fg_models.html) 
 for a list of existing tools). However, these programs are either 
-only usable for the specific experiments for which the tool was made, or unaccessible 
-as they require the use of licensed programing languages or unpractical web 
-interfaces. Much of modern astronomy and cosmology is done in Python due to the wide 
-range of available high quality tools and open source projects and communities, such as 
-the Astropy project [@astropy]. The lack of a general purpose zodiacal light tool 
-in this space was the main motivation behind the development of the `ZodiPy` package.
+only usable for specific experiments or otherwise difficult to access by requiring 
+licensed programming languages or web  interfaces. Many modern astronomy and 
+cosmology pipelines are built in Python due to the wide range of available 
+high-quality tools and open-source projects and communities, such as the Astropy 
+project [@astropy]. The lack of a general-purpose zodiacal light tool in this space 
+was the primary motivation behind the development of the `ZodiPy` package.
 
-When using `ZodiPy`, the user is required to provide the following data: 
+`ZodiPy` can be used to simulate zodiacal light for arbitrary Solar system observers, meaning that researchers no longer have to spend time developing their own tools from scratch. 
+To use `ZodiPy`, the user is required to provide the following data: 
 
-1) A set of observations, in either ecliptic or galactic coordinates, in the form of 
-angular sky coordinates or as HEALPIx [@Gorski2005] pixel indices.
-2) A center frequency or a bandpass.
-3) The time of observation. 
-4) The heliocentric position of the observer, although this may be omitted if the 
-observer is located at the position of a major solar system object, such as on Earth 
-or at the Sun-Earth-Moon barycenter L2. In this case the position is queried directly 
-through the `astropy.coordinates` solar system ephemeridis. 
+1) A sequence of pointings, either in ecliptic or galactic coordinates. These can 
+be specified  as angles on the sky or as HEALPix [@Gorski2005] pixel indices.
+2) A center frequency or an instrument bandpass.
+3) The time of observation, which corresponds to the pointing sequence. 
+4) The heliocentric ecliptic position of the observer. If the observer is located 
+at a major solar system object, such as the Earth or the Sun-Earth-Moon barycenter 
+L2, the position is instead queried through the `astropy.coordinates` Solar system 
+ephemerides. 
 
-This information is then used to evaluate a sequence of line-of-sight integrals through 
-a three-dimensional model of the interplanetary dust distribution. For more details 
-about the implementation and the models used we refer to the following paper on `ZodiPy`
-[@San2022].
+The predicted zodiacal light is then obtained by evaluating a sequence of 
+line-of-sight integrals from the position of the observer and through a 
+model of the three-dimensional interplanetary dust distribution. For 
+implementation details and examples of how to apply `ZodiPy` to a real-world 
+dataset, see[@San2022].
 
-`ZodiPy` has been used by several research projects[@2023arXiv230617219A; 
-@2023arXiv230617226R; @Tsumura2023; @Avitan2023; @Hanzawa2024] with applications ranging from assistance in determining the observational fields of the coming NASA Roman Space Telescope, to model data obtained aboard the Hayabusa2 JAXA satellite. 
+`ZodiPy` has been rapidly adopted by the astronomy community, and the package has 
+already been used by several research projects[@2023arXiv230617219A; 
+@2023arXiv230617226R; @Tsumura2023; @Avitan2023; @Hanzawa2024] with applications 
+ranging from assisting the coming NASA Roman Space Telescope in determining its 
+observational fields to modeling data obtained aboard the Hayabusa2 JAXA satellite. 
 
 # Acknowledgements
 The work to develop `ZodiPy`  has received funding from the European Union’s Horizon 
@@ -76,7 +81,7 @@ The work to develop `ZodiPy`  has received funding from the European Union’s H
 (ERC; Cosmoglobe) and 772253 (ERC;bits2cosmology).
 
 This project relies on the following Python packages: Astropy [@astropy], NumPy 
-[@numpy2011; @numpy2020], healpy [@Zonca2019], SciPy [@scipy2020], jplephem 
+[@numpy2011; @numpy2020], healpy [@Zonca2019], SciPy [@scipy2020], and jplephem 
 [@2011ascl.soft12014R].
 
 # References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -51,8 +51,9 @@ high-quality tools and open-source projects and communities, such as the Astropy
 project [@astropy]. The lack of a general-purpose zodiacal light tool in this space 
 was the primary motivation behind the development of the `ZodiPy` package.
 
-`ZodiPy` can be used to simulate zodiacal light for arbitrary Solar system observers, meaning that researchers no longer have to spend time developing their own tools from scratch. 
-To use `ZodiPy`, the user is required to provide the following data: 
+`ZodiPy` can be used to simulate zodiacal light for arbitrary Solar system observers, 
+meaning that researchers no longer have to spend time developing their own tools from 
+scratch. To use `ZodiPy`, the user is required to provide the following data: 
 
 1) A sequence of pointings, either in ecliptic or galactic coordinates. These can 
 be specified  as angles on the sky or as HEALPix [@Gorski2005] pixel indices.

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -23,6 +23,7 @@ bibliography: paper.bib
 # aas-journal: Astrophysical Journal <- The name of the AAS journal.
 ---
 
+
 # Summary
 `ZodiPy` is an Astropy-affiliated Python package for zodiacal light simulations. 
 Its purpose is to provide the astrophysics and cosmology communities with an 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -46,8 +46,8 @@ light tools (see the
 [LAMBDA foreground models page](https://lambda.gsfc.nasa.gov/product/foreground/fg_models.html) 
 for a list of existing tools). However, these programs are either 
 only usable for specific experiments or otherwise difficult to access by requiring 
-licensed programming languages or web  interfaces. Many modern astronomy and 
-cosmology pipelines are built in Python due to the wide range of available 
+licensed programming languages or the use of web interfaces. Modern astronomy and 
+cosmology pipelines are commonly built in Python due to the wide range of available 
 high-quality tools and open-source projects and communities, such as the Astropy 
 project [@astropy]. The lack of a general-purpose zodiacal light tool in this space 
 was the primary motivation behind the development of the `ZodiPy` package.
@@ -59,9 +59,9 @@ scratch. To use `ZodiPy`, the user is required to provide the following data:
 1) A sequence of pointings, either in ecliptic or galactic coordinates. These can 
 be specified  as angles on the sky or as HEALPix [@Gorski2005] pixel indices.
 2) A center frequency or an instrument bandpass.
-3) The time of observation, which corresponds to the pointing sequence. 
+3) Time of observation, corresponding to the pointing sequence. 
 4) The heliocentric ecliptic position of the observer. If the observer is located 
-at a major solar system object, such as the Earth or the Sun-Earth-Moon barycenter 
+at a major Solar system object, such as the Earth or the Sun-Earth-Moon barycenter 
 L2, the position is instead queried through the `astropy.coordinates` Solar system 
 ephemerides. 
 
@@ -69,20 +69,20 @@ The predicted zodiacal light is then obtained by evaluating a sequence of
 line-of-sight integrals from the position of the observer and through a 
 model of the three-dimensional interplanetary dust distribution. For 
 implementation details and examples of how to apply `ZodiPy` to a real-world 
-dataset, see[@San2022].
+dataset, see @San2022.
 
 `ZodiPy` has been rapidly adopted by the astronomy community, and the package has 
-already been used by several research projects[@2023arXiv230617219A; 
-@2023arXiv230617226R; @Tsumura2023; @Avitan2023; @Hanzawa2024] with applications 
-ranging from assisting the coming NASA Roman Space Telescope in determining its 
-observational fields to modeling data obtained aboard the Hayabusa2 JAXA satellite. 
+already been used by several research projects (see @2023arXiv230617219A; 
+@2023arXiv230617226R; @Tsumura2023; @Avitan2023; @Hanzawa2024), for instance in
+assisting the coming NASA Roman Space Telescope in determining its observational 
+fields, or to modeling data obtained aboard the Hayabusa2 JAXA satellite. 
 
 # Acknowledgements
-The work to develop `ZodiPy`  has received funding from the European Union’s Horizon 
-2020 research and innovation programme under grant agreement numbers 819478 
-(ERC; Cosmoglobe) and 772253 (ERC;bits2cosmology).
+This work has received funding from the European Union’s Horizon 2020 research and 
+innovation programme under grant agreement numbers 819478 (ERC; Cosmoglobe) and 
+772253 (ERC;bits2cosmology).
 
-This project relies on the following Python packages: Astropy [@astropy], NumPy 
+This project uses the following Python packages: Astropy [@astropy], NumPy 
 [@numpy2011; @numpy2020], healpy [@Zonca2019], SciPy [@scipy2020], and jplephem 
 [@2011ascl.soft12014R].
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -475,69 +475,69 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.13.1"
+version = "3.13.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
-    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
+    {file = "filelock-3.13.4-py3-none-any.whl", hash = "sha256:404e5e9253aa60ad457cae1be07c0f0ca90a63931200a47d9b6a6af84fd7b45f"},
+    {file = "filelock-3.13.4.tar.gz", hash = "sha256:d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "fonttools"
-version = "4.50.0"
+version = "4.51.0"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "fonttools-4.50.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:effd303fb422f8ce06543a36ca69148471144c534cc25f30e5be752bc4f46736"},
-    {file = "fonttools-4.50.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7913992ab836f621d06aabac118fc258b9947a775a607e1a737eb3a91c360335"},
-    {file = "fonttools-4.50.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e0a1c5bd2f63da4043b63888534b52c5a1fd7ae187c8ffc64cbb7ae475b9dab"},
-    {file = "fonttools-4.50.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d40fc98540fa5360e7ecf2c56ddf3c6e7dd04929543618fd7b5cc76e66390562"},
-    {file = "fonttools-4.50.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fff65fbb7afe137bac3113827855e0204482727bddd00a806034ab0d3951d0d"},
-    {file = "fonttools-4.50.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b1aeae3dd2ee719074a9372c89ad94f7c581903306d76befdaca2a559f802472"},
-    {file = "fonttools-4.50.0-cp310-cp310-win32.whl", hash = "sha256:e9623afa319405da33b43c85cceb0585a6f5d3a1d7c604daf4f7e1dd55c03d1f"},
-    {file = "fonttools-4.50.0-cp310-cp310-win_amd64.whl", hash = "sha256:778c5f43e7e654ef7fe0605e80894930bc3a7772e2f496238e57218610140f54"},
-    {file = "fonttools-4.50.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3dfb102e7f63b78c832e4539969167ffcc0375b013080e6472350965a5fe8048"},
-    {file = "fonttools-4.50.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9e58fe34cb379ba3d01d5d319d67dd3ce7ca9a47ad044ea2b22635cd2d1247fc"},
-    {file = "fonttools-4.50.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c673ab40d15a442a4e6eb09bf007c1dda47c84ac1e2eecbdf359adacb799c24"},
-    {file = "fonttools-4.50.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b3ac35cdcd1a4c90c23a5200212c1bb74fa05833cc7c14291d7043a52ca2aaa"},
-    {file = "fonttools-4.50.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:8844e7a2c5f7ecf977e82eb6b3014f025c8b454e046d941ece05b768be5847ae"},
-    {file = "fonttools-4.50.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f849bd3c5c2249b49c98eca5aaebb920d2bfd92b3c69e84ca9bddf133e9f83f0"},
-    {file = "fonttools-4.50.0-cp311-cp311-win32.whl", hash = "sha256:39293ff231b36b035575e81c14626dfc14407a20de5262f9596c2cbb199c3625"},
-    {file = "fonttools-4.50.0-cp311-cp311-win_amd64.whl", hash = "sha256:c33d5023523b44d3481624f840c8646656a1def7630ca562f222eb3ead16c438"},
-    {file = "fonttools-4.50.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b4a886a6dbe60100ba1cd24de962f8cd18139bd32808da80de1fa9f9f27bf1dc"},
-    {file = "fonttools-4.50.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b2ca1837bfbe5eafa11313dbc7edada79052709a1fffa10cea691210af4aa1fa"},
-    {file = "fonttools-4.50.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0493dd97ac8977e48ffc1476b932b37c847cbb87fd68673dee5182004906828"},
-    {file = "fonttools-4.50.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77844e2f1b0889120b6c222fc49b2b75c3d88b930615e98893b899b9352a27ea"},
-    {file = "fonttools-4.50.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3566bfb8c55ed9100afe1ba6f0f12265cd63a1387b9661eb6031a1578a28bad1"},
-    {file = "fonttools-4.50.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:35e10ddbc129cf61775d58a14f2d44121178d89874d32cae1eac722e687d9019"},
-    {file = "fonttools-4.50.0-cp312-cp312-win32.whl", hash = "sha256:cc8140baf9fa8f9b903f2b393a6c413a220fa990264b215bf48484f3d0bf8710"},
-    {file = "fonttools-4.50.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ccc85fd96373ab73c59833b824d7a73846670a0cb1f3afbaee2b2c426a8f931"},
-    {file = "fonttools-4.50.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e270a406219af37581d96c810172001ec536e29e5593aa40d4c01cca3e145aa6"},
-    {file = "fonttools-4.50.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ac2463de667233372e9e1c7e9de3d914b708437ef52a3199fdbf5a60184f190c"},
-    {file = "fonttools-4.50.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47abd6669195abe87c22750dbcd366dc3a0648f1b7c93c2baa97429c4dc1506e"},
-    {file = "fonttools-4.50.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:074841375e2e3d559aecc86e1224caf78e8b8417bb391e7d2506412538f21adc"},
-    {file = "fonttools-4.50.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0743fd2191ad7ab43d78cd747215b12033ddee24fa1e088605a3efe80d6984de"},
-    {file = "fonttools-4.50.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3d7080cce7be5ed65bee3496f09f79a82865a514863197ff4d4d177389e981b0"},
-    {file = "fonttools-4.50.0-cp38-cp38-win32.whl", hash = "sha256:a467ba4e2eadc1d5cc1a11d355abb945f680473fbe30d15617e104c81f483045"},
-    {file = "fonttools-4.50.0-cp38-cp38-win_amd64.whl", hash = "sha256:f77e048f805e00870659d6318fd89ef28ca4ee16a22b4c5e1905b735495fc422"},
-    {file = "fonttools-4.50.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b6245eafd553c4e9a0708e93be51392bd2288c773523892fbd616d33fd2fda59"},
-    {file = "fonttools-4.50.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a4062cc7e8de26f1603323ef3ae2171c9d29c8a9f5e067d555a2813cd5c7a7e0"},
-    {file = "fonttools-4.50.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34692850dfd64ba06af61e5791a441f664cb7d21e7b544e8f385718430e8f8e4"},
-    {file = "fonttools-4.50.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:678dd95f26a67e02c50dcb5bf250f95231d455642afbc65a3b0bcdacd4e4dd38"},
-    {file = "fonttools-4.50.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4f2ce7b0b295fe64ac0a85aef46a0f2614995774bd7bc643b85679c0283287f9"},
-    {file = "fonttools-4.50.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d346f4dc2221bfb7ab652d1e37d327578434ce559baf7113b0f55768437fe6a0"},
-    {file = "fonttools-4.50.0-cp39-cp39-win32.whl", hash = "sha256:a51eeaf52ba3afd70bf489be20e52fdfafe6c03d652b02477c6ce23c995222f4"},
-    {file = "fonttools-4.50.0-cp39-cp39-win_amd64.whl", hash = "sha256:8639be40d583e5d9da67795aa3eeeda0488fb577a1d42ae11a5036f18fb16d93"},
-    {file = "fonttools-4.50.0-py3-none-any.whl", hash = "sha256:48fa36da06247aa8282766cfd63efff1bb24e55f020f29a335939ed3844d20d3"},
-    {file = "fonttools-4.50.0.tar.gz", hash = "sha256:fa5cf61058c7dbb104c2ac4e782bf1b2016a8cf2f69de6e4dd6a865d2c969bb5"},
+    {file = "fonttools-4.51.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:84d7751f4468dd8cdd03ddada18b8b0857a5beec80bce9f435742abc9a851a74"},
+    {file = "fonttools-4.51.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8b4850fa2ef2cfbc1d1f689bc159ef0f45d8d83298c1425838095bf53ef46308"},
+    {file = "fonttools-4.51.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5b48a1121117047d82695d276c2af2ee3a24ffe0f502ed581acc2673ecf1037"},
+    {file = "fonttools-4.51.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:180194c7fe60c989bb627d7ed5011f2bef1c4d36ecf3ec64daec8302f1ae0716"},
+    {file = "fonttools-4.51.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:96a48e137c36be55e68845fc4284533bda2980f8d6f835e26bca79d7e2006438"},
+    {file = "fonttools-4.51.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:806e7912c32a657fa39d2d6eb1d3012d35f841387c8fc6cf349ed70b7c340039"},
+    {file = "fonttools-4.51.0-cp310-cp310-win32.whl", hash = "sha256:32b17504696f605e9e960647c5f64b35704782a502cc26a37b800b4d69ff3c77"},
+    {file = "fonttools-4.51.0-cp310-cp310-win_amd64.whl", hash = "sha256:c7e91abdfae1b5c9e3a543f48ce96013f9a08c6c9668f1e6be0beabf0a569c1b"},
+    {file = "fonttools-4.51.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a8feca65bab31479d795b0d16c9a9852902e3a3c0630678efb0b2b7941ea9c74"},
+    {file = "fonttools-4.51.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ac27f436e8af7779f0bb4d5425aa3535270494d3bc5459ed27de3f03151e4c2"},
+    {file = "fonttools-4.51.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e19bd9e9964a09cd2433a4b100ca7f34e34731e0758e13ba9a1ed6e5468cc0f"},
+    {file = "fonttools-4.51.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2b92381f37b39ba2fc98c3a45a9d6383bfc9916a87d66ccb6553f7bdd129097"},
+    {file = "fonttools-4.51.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5f6bc991d1610f5c3bbe997b0233cbc234b8e82fa99fc0b2932dc1ca5e5afec0"},
+    {file = "fonttools-4.51.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9696fe9f3f0c32e9a321d5268208a7cc9205a52f99b89479d1b035ed54c923f1"},
+    {file = "fonttools-4.51.0-cp311-cp311-win32.whl", hash = "sha256:3bee3f3bd9fa1d5ee616ccfd13b27ca605c2b4270e45715bd2883e9504735034"},
+    {file = "fonttools-4.51.0-cp311-cp311-win_amd64.whl", hash = "sha256:0f08c901d3866a8905363619e3741c33f0a83a680d92a9f0e575985c2634fcc1"},
+    {file = "fonttools-4.51.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:4060acc2bfa2d8e98117828a238889f13b6f69d59f4f2d5857eece5277b829ba"},
+    {file = "fonttools-4.51.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1250e818b5f8a679ad79660855528120a8f0288f8f30ec88b83db51515411fcc"},
+    {file = "fonttools-4.51.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76f1777d8b3386479ffb4a282e74318e730014d86ce60f016908d9801af9ca2a"},
+    {file = "fonttools-4.51.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b5ad456813d93b9c4b7ee55302208db2b45324315129d85275c01f5cb7e61a2"},
+    {file = "fonttools-4.51.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:68b3fb7775a923be73e739f92f7e8a72725fd333eab24834041365d2278c3671"},
+    {file = "fonttools-4.51.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8e2f1a4499e3b5ee82c19b5ee57f0294673125c65b0a1ff3764ea1f9db2f9ef5"},
+    {file = "fonttools-4.51.0-cp312-cp312-win32.whl", hash = "sha256:278e50f6b003c6aed19bae2242b364e575bcb16304b53f2b64f6551b9c000e15"},
+    {file = "fonttools-4.51.0-cp312-cp312-win_amd64.whl", hash = "sha256:b3c61423f22165541b9403ee39874dcae84cd57a9078b82e1dce8cb06b07fa2e"},
+    {file = "fonttools-4.51.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1621ee57da887c17312acc4b0e7ac30d3a4fb0fec6174b2e3754a74c26bbed1e"},
+    {file = "fonttools-4.51.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9d9298be7a05bb4801f558522adbe2feea1b0b103d5294ebf24a92dd49b78e5"},
+    {file = "fonttools-4.51.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee1af4be1c5afe4c96ca23badd368d8dc75f611887fb0c0dac9f71ee5d6f110e"},
+    {file = "fonttools-4.51.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c18b49adc721a7d0b8dfe7c3130c89b8704baf599fb396396d07d4aa69b824a1"},
+    {file = "fonttools-4.51.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:de7c29bdbdd35811f14493ffd2534b88f0ce1b9065316433b22d63ca1cd21f14"},
+    {file = "fonttools-4.51.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:cadf4e12a608ef1d13e039864f484c8a968840afa0258b0b843a0556497ea9ed"},
+    {file = "fonttools-4.51.0-cp38-cp38-win32.whl", hash = "sha256:aefa011207ed36cd280babfaa8510b8176f1a77261833e895a9d96e57e44802f"},
+    {file = "fonttools-4.51.0-cp38-cp38-win_amd64.whl", hash = "sha256:865a58b6e60b0938874af0968cd0553bcd88e0b2cb6e588727117bd099eef836"},
+    {file = "fonttools-4.51.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:60a3409c9112aec02d5fb546f557bca6efa773dcb32ac147c6baf5f742e6258b"},
+    {file = "fonttools-4.51.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7e89853d8bea103c8e3514b9f9dc86b5b4120afb4583b57eb10dfa5afbe0936"},
+    {file = "fonttools-4.51.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56fc244f2585d6c00b9bcc59e6593e646cf095a96fe68d62cd4da53dd1287b55"},
+    {file = "fonttools-4.51.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d145976194a5242fdd22df18a1b451481a88071feadf251221af110ca8f00ce"},
+    {file = "fonttools-4.51.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c5b8cab0c137ca229433570151b5c1fc6af212680b58b15abd797dcdd9dd5051"},
+    {file = "fonttools-4.51.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:54dcf21a2f2d06ded676e3c3f9f74b2bafded3a8ff12f0983160b13e9f2fb4a7"},
+    {file = "fonttools-4.51.0-cp39-cp39-win32.whl", hash = "sha256:0118ef998a0699a96c7b28457f15546815015a2710a1b23a7bf6c1be60c01636"},
+    {file = "fonttools-4.51.0-cp39-cp39-win_amd64.whl", hash = "sha256:599bdb75e220241cedc6faebfafedd7670335d2e29620d207dd0378a4e9ccc5a"},
+    {file = "fonttools-4.51.0-py3-none-any.whl", hash = "sha256:15c94eeef6b095831067f72c825eb0e2d48bb4cea0647c1b05c981ecba2bf39f"},
+    {file = "fonttools-4.51.0.tar.gz", hash = "sha256:dc0673361331566d7a663d7ce0f6fdcbfbdc1f59c6e3ed1165ad7202ca183c68"},
 ]
 
 [package.extras]
@@ -619,13 +619,13 @@ test = ["pytest", "pytest-cython", "pytest-doctestplus", "requests"]
 
 [[package]]
 name = "hypothesis"
-version = "6.99.11"
+version = "6.100.1"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "hypothesis-6.99.11-py3-none-any.whl", hash = "sha256:9c010b219ec611c995bac7e11a3edc96cea3c2c0b04a9d08ec586a7981715353"},
-    {file = "hypothesis-6.99.11.tar.gz", hash = "sha256:3df99ecf501e056c7e2c6ac7a9e3726f4fe8d2139dcce068aceffdab58265f1e"},
+    {file = "hypothesis-6.100.1-py3-none-any.whl", hash = "sha256:3dacf6ec90e8d14aaee02cde081ac9a17d5b70105e45e6ac822db72052c0195b"},
+    {file = "hypothesis-6.100.1.tar.gz", hash = "sha256:ebff09d7fa4f1fb6a855a812baf17e578b4481b7b70ec6d96496210d1a4c6c35"},
 ]
 
 [package.dependencies]
@@ -634,10 +634,10 @@ exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
-all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "crosshair-tool (>=0.0.51)", "django (>=3.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.2)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.17.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2024.1)"]
+all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "crosshair-tool (>=0.0.54)", "django (>=3.2)", "dpcontracts (>=0.4)", "hypothesis-crosshair (>=0.0.2)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.17.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2024.1)"]
 cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
 codemods = ["libcst (>=0.3.16)"]
-crosshair = ["crosshair-tool (>=0.0.51)", "hypothesis-crosshair (>=0.0.2)"]
+crosshair = ["crosshair-tool (>=0.0.54)", "hypothesis-crosshair (>=0.0.2)"]
 dateutil = ["python-dateutil (>=1.4)"]
 django = ["django (>=3.2)"]
 dpcontracts = ["dpcontracts (>=0.4)"]
@@ -696,13 +696,13 @@ testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)",
 
 [[package]]
 name = "importlib-resources"
-version = "6.3.2"
+version = "6.4.0"
 description = "Read resources from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.3.2-py3-none-any.whl", hash = "sha256:f41f4098b16cd140a97d256137cfd943d958219007990b2afb00439fc623f580"},
-    {file = "importlib_resources-6.3.2.tar.gz", hash = "sha256:963eb79649252b0160c1afcfe5a1d3fe3ad66edd0a8b114beacffb70c0674223"},
+    {file = "importlib_resources-6.4.0-py3-none-any.whl", hash = "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c"},
+    {file = "importlib_resources-6.4.0.tar.gz", hash = "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"},
 ]
 
 [package.dependencies]
@@ -710,7 +710,7 @@ zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["jaraco.collections", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
+testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
 
 [[package]]
 name = "iniconfig"
@@ -1153,13 +1153,13 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.9.0"
+version = "1.9.1"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.9.0-py3-none-any.whl", hash = "sha256:fad27d7314b4ec9c0359a187b477fb94c65ef561fdae941dca1b717c59aae96f"},
-    {file = "mkdocstrings_python-1.9.0.tar.gz", hash = "sha256:6e1a442367cf75d30cf69774cbb1ad02aebec58bfff26087439df4955efecfde"},
+    {file = "mkdocstrings_python-1.9.1-py3-none-any.whl", hash = "sha256:bf2406ed37ff19c9f8e0acc9d72c41953fb789bfb4ae10eb00ee17e537eeb220"},
+    {file = "mkdocstrings_python-1.9.1.tar.gz", hash = "sha256:077188fa43eab3b689826b15da7da6753501224b2482e4eca3ce4412ce3b71cb"},
 ]
 
 [package.dependencies]
@@ -1300,79 +1300,80 @@ files = [
 
 [[package]]
 name = "pillow"
-version = "10.2.0"
+version = "10.3.0"
 description = "Python Imaging Library (Fork)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pillow-10.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:7823bdd049099efa16e4246bdf15e5a13dbb18a51b68fa06d6c1d4d8b99a796e"},
-    {file = "pillow-10.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:83b2021f2ade7d1ed556bc50a399127d7fb245e725aa0113ebd05cfe88aaf588"},
-    {file = "pillow-10.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fad5ff2f13d69b7e74ce5b4ecd12cc0ec530fcee76356cac6742785ff71c452"},
-    {file = "pillow-10.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da2b52b37dad6d9ec64e653637a096905b258d2fc2b984c41ae7d08b938a67e4"},
-    {file = "pillow-10.2.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:47c0995fc4e7f79b5cfcab1fc437ff2890b770440f7696a3ba065ee0fd496563"},
-    {file = "pillow-10.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:322bdf3c9b556e9ffb18f93462e5f749d3444ce081290352c6070d014c93feb2"},
-    {file = "pillow-10.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:51f1a1bffc50e2e9492e87d8e09a17c5eea8409cda8d3f277eb6edc82813c17c"},
-    {file = "pillow-10.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:69ffdd6120a4737710a9eee73e1d2e37db89b620f702754b8f6e62594471dee0"},
-    {file = "pillow-10.2.0-cp310-cp310-win32.whl", hash = "sha256:c6dafac9e0f2b3c78df97e79af707cdc5ef8e88208d686a4847bab8266870023"},
-    {file = "pillow-10.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:aebb6044806f2e16ecc07b2a2637ee1ef67a11840a66752751714a0d924adf72"},
-    {file = "pillow-10.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:7049e301399273a0136ff39b84c3678e314f2158f50f517bc50285fb5ec847ad"},
-    {file = "pillow-10.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:35bb52c37f256f662abdfa49d2dfa6ce5d93281d323a9af377a120e89a9eafb5"},
-    {file = "pillow-10.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c23f307202661071d94b5e384e1e1dc7dfb972a28a2310e4ee16103e66ddb67"},
-    {file = "pillow-10.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:773efe0603db30c281521a7c0214cad7836c03b8ccff897beae9b47c0b657d61"},
-    {file = "pillow-10.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11fa2e5984b949b0dd6d7a94d967743d87c577ff0b83392f17cb3990d0d2fd6e"},
-    {file = "pillow-10.2.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:716d30ed977be8b37d3ef185fecb9e5a1d62d110dfbdcd1e2a122ab46fddb03f"},
-    {file = "pillow-10.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a086c2af425c5f62a65e12fbf385f7c9fcb8f107d0849dba5839461a129cf311"},
-    {file = "pillow-10.2.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c8de2789052ed501dd829e9cae8d3dcce7acb4777ea4a479c14521c942d395b1"},
-    {file = "pillow-10.2.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:609448742444d9290fd687940ac0b57fb35e6fd92bdb65386e08e99af60bf757"},
-    {file = "pillow-10.2.0-cp311-cp311-win32.whl", hash = "sha256:823ef7a27cf86df6597fa0671066c1b596f69eba53efa3d1e1cb8b30f3533068"},
-    {file = "pillow-10.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:1da3b2703afd040cf65ec97efea81cfba59cdbed9c11d8efc5ab09df9509fc56"},
-    {file = "pillow-10.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:edca80cbfb2b68d7b56930b84a0e45ae1694aeba0541f798e908a49d66b837f1"},
-    {file = "pillow-10.2.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:1b5e1b74d1bd1b78bc3477528919414874748dd363e6272efd5abf7654e68bef"},
-    {file = "pillow-10.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0eae2073305f451d8ecacb5474997c08569fb4eb4ac231ffa4ad7d342fdc25ac"},
-    {file = "pillow-10.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7c2286c23cd350b80d2fc9d424fc797575fb16f854b831d16fd47ceec078f2c"},
-    {file = "pillow-10.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e23412b5c41e58cec602f1135c57dfcf15482013ce6e5f093a86db69646a5aa"},
-    {file = "pillow-10.2.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:52a50aa3fb3acb9cf7213573ef55d31d6eca37f5709c69e6858fe3bc04a5c2a2"},
-    {file = "pillow-10.2.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:127cee571038f252a552760076407f9cff79761c3d436a12af6000cd182a9d04"},
-    {file = "pillow-10.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:8d12251f02d69d8310b046e82572ed486685c38f02176bd08baf216746eb947f"},
-    {file = "pillow-10.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:54f1852cd531aa981bc0965b7d609f5f6cc8ce8c41b1139f6ed6b3c54ab82bfb"},
-    {file = "pillow-10.2.0-cp312-cp312-win32.whl", hash = "sha256:257d8788df5ca62c980314053197f4d46eefedf4e6175bc9412f14412ec4ea2f"},
-    {file = "pillow-10.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:154e939c5f0053a383de4fd3d3da48d9427a7e985f58af8e94d0b3c9fcfcf4f9"},
-    {file = "pillow-10.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:f379abd2f1e3dddb2b61bc67977a6b5a0a3f7485538bcc6f39ec76163891ee48"},
-    {file = "pillow-10.2.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:8373c6c251f7ef8bda6675dd6d2b3a0fcc31edf1201266b5cf608b62a37407f9"},
-    {file = "pillow-10.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:870ea1ada0899fd0b79643990809323b389d4d1d46c192f97342eeb6ee0b8483"},
-    {file = "pillow-10.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4b6b1e20608493548b1f32bce8cca185bf0480983890403d3b8753e44077129"},
-    {file = "pillow-10.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3031709084b6e7852d00479fd1d310b07d0ba82765f973b543c8af5061cf990e"},
-    {file = "pillow-10.2.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:3ff074fc97dd4e80543a3e91f69d58889baf2002b6be64347ea8cf5533188213"},
-    {file = "pillow-10.2.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:cb4c38abeef13c61d6916f264d4845fab99d7b711be96c326b84df9e3e0ff62d"},
-    {file = "pillow-10.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b1b3020d90c2d8e1dae29cf3ce54f8094f7938460fb5ce8bc5c01450b01fbaf6"},
-    {file = "pillow-10.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:170aeb00224ab3dc54230c797f8404507240dd868cf52066f66a41b33169bdbe"},
-    {file = "pillow-10.2.0-cp38-cp38-win32.whl", hash = "sha256:c4225f5220f46b2fde568c74fca27ae9771536c2e29d7c04f4fb62c83275ac4e"},
-    {file = "pillow-10.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:0689b5a8c5288bc0504d9fcee48f61a6a586b9b98514d7d29b840143d6734f39"},
-    {file = "pillow-10.2.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:b792a349405fbc0163190fde0dc7b3fef3c9268292586cf5645598b48e63dc67"},
-    {file = "pillow-10.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c570f24be1e468e3f0ce7ef56a89a60f0e05b30a3669a459e419c6eac2c35364"},
-    {file = "pillow-10.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8ecd059fdaf60c1963c58ceb8997b32e9dc1b911f5da5307aab614f1ce5c2fb"},
-    {file = "pillow-10.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c365fd1703040de1ec284b176d6af5abe21b427cb3a5ff68e0759e1e313a5e7e"},
-    {file = "pillow-10.2.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:70c61d4c475835a19b3a5aa42492409878bbca7438554a1f89d20d58a7c75c01"},
-    {file = "pillow-10.2.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b6f491cdf80ae540738859d9766783e3b3c8e5bd37f5dfa0b76abdecc5081f13"},
-    {file = "pillow-10.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9d189550615b4948f45252d7f005e53c2040cea1af5b60d6f79491a6e147eef7"},
-    {file = "pillow-10.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:49d9ba1ed0ef3e061088cd1e7538a0759aab559e2e0a80a36f9fd9d8c0c21591"},
-    {file = "pillow-10.2.0-cp39-cp39-win32.whl", hash = "sha256:babf5acfede515f176833ed6028754cbcd0d206f7f614ea3447d67c33be12516"},
-    {file = "pillow-10.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:0304004f8067386b477d20a518b50f3fa658a28d44e4116970abfcd94fac34a8"},
-    {file = "pillow-10.2.0-cp39-cp39-win_arm64.whl", hash = "sha256:0fb3e7fc88a14eacd303e90481ad983fd5b69c761e9e6ef94c983f91025da869"},
-    {file = "pillow-10.2.0-pp310-pypy310_pp73-macosx_10_10_x86_64.whl", hash = "sha256:322209c642aabdd6207517e9739c704dc9f9db943015535783239022002f054a"},
-    {file = "pillow-10.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3eedd52442c0a5ff4f887fab0c1c0bb164d8635b32c894bc1faf4c618dd89df2"},
-    {file = "pillow-10.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb28c753fd5eb3dd859b4ee95de66cc62af91bcff5db5f2571d32a520baf1f04"},
-    {file = "pillow-10.2.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:33870dc4653c5017bf4c8873e5488d8f8d5f8935e2f1fb9a2208c47cdd66efd2"},
-    {file = "pillow-10.2.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:3c31822339516fb3c82d03f30e22b1d038da87ef27b6a78c9549888f8ceda39a"},
-    {file = "pillow-10.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a2b56ba36e05f973d450582fb015594aaa78834fefe8dfb8fcd79b93e64ba4c6"},
-    {file = "pillow-10.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d8e6aeb9201e655354b3ad049cb77d19813ad4ece0df1249d3c793de3774f8c7"},
-    {file = "pillow-10.2.0-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:2247178effb34a77c11c0e8ac355c7a741ceca0a732b27bf11e747bbc950722f"},
-    {file = "pillow-10.2.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15587643b9e5eb26c48e49a7b33659790d28f190fc514a322d55da2fb5c2950e"},
-    {file = "pillow-10.2.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753cd8f2086b2b80180d9b3010dd4ed147efc167c90d3bf593fe2af21265e5a5"},
-    {file = "pillow-10.2.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7c8f97e8e7a9009bcacbe3766a36175056c12f9a44e6e6f2d5caad06dcfbf03b"},
-    {file = "pillow-10.2.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d1b35bcd6c5543b9cb547dee3150c93008f8dd0f1fef78fc0cd2b141c5baf58a"},
-    {file = "pillow-10.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:fe4c15f6c9285dc54ce6553a3ce908ed37c8f3825b5a51a15c91442bb955b868"},
-    {file = "pillow-10.2.0.tar.gz", hash = "sha256:e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e"},
+    {file = "pillow-10.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:90b9e29824800e90c84e4022dd5cc16eb2d9605ee13f05d47641eb183cd73d45"},
+    {file = "pillow-10.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a2c405445c79c3f5a124573a051062300936b0281fee57637e706453e452746c"},
+    {file = "pillow-10.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78618cdbccaa74d3f88d0ad6cb8ac3007f1a6fa5c6f19af64b55ca170bfa1edf"},
+    {file = "pillow-10.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:261ddb7ca91fcf71757979534fb4c128448b5b4c55cb6152d280312062f69599"},
+    {file = "pillow-10.3.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:ce49c67f4ea0609933d01c0731b34b8695a7a748d6c8d186f95e7d085d2fe475"},
+    {file = "pillow-10.3.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b14f16f94cbc61215115b9b1236f9c18403c15dd3c52cf629072afa9d54c1cbf"},
+    {file = "pillow-10.3.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d33891be6df59d93df4d846640f0e46f1a807339f09e79a8040bc887bdcd7ed3"},
+    {file = "pillow-10.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b50811d664d392f02f7761621303eba9d1b056fb1868c8cdf4231279645c25f5"},
+    {file = "pillow-10.3.0-cp310-cp310-win32.whl", hash = "sha256:ca2870d5d10d8726a27396d3ca4cf7976cec0f3cb706debe88e3a5bd4610f7d2"},
+    {file = "pillow-10.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:f0d0591a0aeaefdaf9a5e545e7485f89910c977087e7de2b6c388aec32011e9f"},
+    {file = "pillow-10.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:ccce24b7ad89adb5a1e34a6ba96ac2530046763912806ad4c247356a8f33a67b"},
+    {file = "pillow-10.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:5f77cf66e96ae734717d341c145c5949c63180842a545c47a0ce7ae52ca83795"},
+    {file = "pillow-10.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4b878386c4bf293578b48fc570b84ecfe477d3b77ba39a6e87150af77f40c57"},
+    {file = "pillow-10.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdcbb4068117dfd9ce0138d068ac512843c52295ed996ae6dd1faf537b6dbc27"},
+    {file = "pillow-10.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9797a6c8fe16f25749b371c02e2ade0efb51155e767a971c61734b1bf6293994"},
+    {file = "pillow-10.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9e91179a242bbc99be65e139e30690e081fe6cb91a8e77faf4c409653de39451"},
+    {file = "pillow-10.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1b87bd9d81d179bd8ab871603bd80d8645729939f90b71e62914e816a76fc6bd"},
+    {file = "pillow-10.3.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:81d09caa7b27ef4e61cb7d8fbf1714f5aec1c6b6c5270ee53504981e6e9121ad"},
+    {file = "pillow-10.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:048ad577748b9fa4a99a0548c64f2cb8d672d5bf2e643a739ac8faff1164238c"},
+    {file = "pillow-10.3.0-cp311-cp311-win32.whl", hash = "sha256:7161ec49ef0800947dc5570f86568a7bb36fa97dd09e9827dc02b718c5643f09"},
+    {file = "pillow-10.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8eb0908e954d093b02a543dc963984d6e99ad2b5e36503d8a0aaf040505f747d"},
+    {file = "pillow-10.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:4e6f7d1c414191c1199f8996d3f2282b9ebea0945693fb67392c75a3a320941f"},
+    {file = "pillow-10.3.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:e46f38133e5a060d46bd630faa4d9fa0202377495df1f068a8299fd78c84de84"},
+    {file = "pillow-10.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:50b8eae8f7334ec826d6eeffaeeb00e36b5e24aa0b9df322c247539714c6df19"},
+    {file = "pillow-10.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d3bea1c75f8c53ee4d505c3e67d8c158ad4df0d83170605b50b64025917f338"},
+    {file = "pillow-10.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19aeb96d43902f0a783946a0a87dbdad5c84c936025b8419da0a0cd7724356b1"},
+    {file = "pillow-10.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:74d28c17412d9caa1066f7a31df8403ec23d5268ba46cd0ad2c50fb82ae40462"},
+    {file = "pillow-10.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ff61bfd9253c3915e6d41c651d5f962da23eda633cf02262990094a18a55371a"},
+    {file = "pillow-10.3.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d886f5d353333b4771d21267c7ecc75b710f1a73d72d03ca06df49b09015a9ef"},
+    {file = "pillow-10.3.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4b5ec25d8b17217d635f8935dbc1b9aa5907962fae29dff220f2659487891cd3"},
+    {file = "pillow-10.3.0-cp312-cp312-win32.whl", hash = "sha256:51243f1ed5161b9945011a7360e997729776f6e5d7005ba0c6879267d4c5139d"},
+    {file = "pillow-10.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:412444afb8c4c7a6cc11a47dade32982439925537e483be7c0ae0cf96c4f6a0b"},
+    {file = "pillow-10.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:798232c92e7665fe82ac085f9d8e8ca98826f8e27859d9a96b41d519ecd2e49a"},
+    {file = "pillow-10.3.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:4eaa22f0d22b1a7e93ff0a596d57fdede2e550aecffb5a1ef1106aaece48e96b"},
+    {file = "pillow-10.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cd5e14fbf22a87321b24c88669aad3a51ec052eb145315b3da3b7e3cc105b9a2"},
+    {file = "pillow-10.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1530e8f3a4b965eb6a7785cf17a426c779333eb62c9a7d1bbcf3ffd5bf77a4aa"},
+    {file = "pillow-10.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d512aafa1d32efa014fa041d38868fda85028e3f930a96f85d49c7d8ddc0383"},
+    {file = "pillow-10.3.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:339894035d0ede518b16073bdc2feef4c991ee991a29774b33e515f1d308e08d"},
+    {file = "pillow-10.3.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:aa7e402ce11f0885305bfb6afb3434b3cd8f53b563ac065452d9d5654c7b86fd"},
+    {file = "pillow-10.3.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:0ea2a783a2bdf2a561808fe4a7a12e9aa3799b701ba305de596bc48b8bdfce9d"},
+    {file = "pillow-10.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c78e1b00a87ce43bb37642c0812315b411e856a905d58d597750eb79802aaaa3"},
+    {file = "pillow-10.3.0-cp38-cp38-win32.whl", hash = "sha256:72d622d262e463dfb7595202d229f5f3ab4b852289a1cd09650362db23b9eb0b"},
+    {file = "pillow-10.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:2034f6759a722da3a3dbd91a81148cf884e91d1b747992ca288ab88c1de15999"},
+    {file = "pillow-10.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:2ed854e716a89b1afcedea551cd85f2eb2a807613752ab997b9974aaa0d56936"},
+    {file = "pillow-10.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dc1a390a82755a8c26c9964d457d4c9cbec5405896cba94cf51f36ea0d855002"},
+    {file = "pillow-10.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4203efca580f0dd6f882ca211f923168548f7ba334c189e9eab1178ab840bf60"},
+    {file = "pillow-10.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3102045a10945173d38336f6e71a8dc71bcaeed55c3123ad4af82c52807b9375"},
+    {file = "pillow-10.3.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:6fb1b30043271ec92dc65f6d9f0b7a830c210b8a96423074b15c7bc999975f57"},
+    {file = "pillow-10.3.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:1dfc94946bc60ea375cc39cff0b8da6c7e5f8fcdc1d946beb8da5c216156ddd8"},
+    {file = "pillow-10.3.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b09b86b27a064c9624d0a6c54da01c1beaf5b6cadfa609cf63789b1d08a797b9"},
+    {file = "pillow-10.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d3b2348a78bc939b4fed6552abfd2e7988e0f81443ef3911a4b8498ca084f6eb"},
+    {file = "pillow-10.3.0-cp39-cp39-win32.whl", hash = "sha256:45ebc7b45406febf07fef35d856f0293a92e7417ae7933207e90bf9090b70572"},
+    {file = "pillow-10.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:0ba26351b137ca4e0db0342d5d00d2e355eb29372c05afd544ebf47c0956ffeb"},
+    {file = "pillow-10.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:50fd3f6b26e3441ae07b7c979309638b72abc1a25da31a81a7fbd9495713ef4f"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-macosx_10_10_x86_64.whl", hash = "sha256:6b02471b72526ab8a18c39cb7967b72d194ec53c1fd0a70b050565a0f366d355"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8ab74c06ffdab957d7670c2a5a6e1a70181cd10b727cd788c4dd9005b6a8acd9"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:048eeade4c33fdf7e08da40ef402e748df113fd0b4584e32c4af74fe78baaeb2"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2ec1e921fd07c7cda7962bad283acc2f2a9ccc1b971ee4b216b75fad6f0463"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:4c8e73e99da7db1b4cad7f8d682cf6abad7844da39834c288fbfa394a47bbced"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:16563993329b79513f59142a6b02055e10514c1a8e86dca8b48a893e33cf91e3"},
+    {file = "pillow-10.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:dd78700f5788ae180b5ee8902c6aea5a5726bac7c364b202b4b3e3ba2d293170"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:aff76a55a8aa8364d25400a210a65ff59d0168e0b4285ba6bf2bd83cf675ba32"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:b7bc2176354defba3edc2b9a777744462da2f8e921fbaf61e52acb95bafa9828"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:793b4e24db2e8742ca6423d3fde8396db336698c55cd34b660663ee9e45ed37f"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d93480005693d247f8346bc8ee28c72a2191bdf1f6b5db469c096c0c867ac015"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83341b89884e2b2e55886e8fbbf37c3fa5efd6c8907124aeb72f285ae5696e5"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1a1d1915db1a4fdb2754b9de292642a39a7fb28f1736699527bb649484fb966a"},
+    {file = "pillow-10.3.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a0eaa93d054751ee9964afa21c06247779b90440ca41d184aeb5d410f20ff591"},
+    {file = "pillow-10.3.0.tar.gz", hash = "sha256:9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d"},
 ]
 
 [package.extras]
@@ -1896,13 +1897,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.10.0"
+version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
-    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]
@@ -2015,4 +2016,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "7950300618bb5f2a956f670c1132cf7ffe78a90050bec4f26c24c38cc5685684"
+content-hash = "044ce5506bc0903699cf6a8fe1d8ea6ec6dc2fb029ea628b98559a3829f85ba1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2016,4 +2016,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "044ce5506bc0903699cf6a8fe1d8ea6ec6dc2fb029ea628b98559a3829f85ba1"
+content-hash = "9a2c9ce54a955ef861e708abac33646d3b184d7d3d14821b617cae1915a72785"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ numpy = "^1.22.3"
 healpy = "^1.15.0"
 astropy = ">=5.0.1"
 jplephem = "^2.17"
+scipy = "^1.9.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"


### PR DESCRIPTION
This pull requests adds a new `paper/` directory containing the paper to be submitted to JOSS. Additionally, SciPy which is used in to perform interpolation was not listed as a direct dependecy, which is also now updated.